### PR TITLE
.gitmodules: switch checkout URL to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/sctplab/usrsctp.git
 [submodule "contrib/avs"]
 	path = contrib/avs
-	url = git@github.com:wireapp/wire-avs.git
+	url = https://github.com/wireapp/wire-avs.git


### PR DESCRIPTION
This is all public repositories, so they can be fetched via https.

We do the same for all downstream git submodules inside https://github.com/wireapp/wire-avs/blob/main/.gitmodules too.