### PR TITLE
WPB-6810: Centralized config for wire-builds + production releases

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -302,11 +302,11 @@ pipeline {
                         env.TARGET_BRANCHES = sh(script: '''#!/usr/bin/env bash
                         set -eo pipefail
 
+                        target_branches=$(jq '.[$var].target_branches // [] | join(" ")' -r --arg var $BRANCH_NAME < "$SFT_WIRE_BUILDS_TARGET_BRANCHES")
                         if [ "$IS_MAIN_RELEASE" = "1" ]; then
-                            echo "main"
-                        else
-                            jq '.[$var].target_branches // [] | join(" ")' -r --arg var $BRANCH_NAME < "$SFT_WIRE_BUILDS_TARGET_BRANCHES"
+                            target_branches="$target_branches main"
                         fi
+                        echo "$target_branches"
                         ''', returnStdout: true)
 
                         sh '''


### PR DESCRIPTION
This PR updates the Jenkins pipeline:

- If the commit contains a tag of pattern `*production*` then the `main` wire-builds target branch will be targeted
- otherwise a centralized configuration file managed inside Jenkins steers the mapping
- Removes some clauses, because I've limited the `sftd` multibranch branches via filter setting. Use that one instead
