### PR TITLE
feat/vferdinandov/WPB 15480 Helm chart upgrade

### DIFF
--- a/charts/sftd/templates/deployment-join-call.yaml
+++ b/charts/sftd/templates/deployment-join-call.yaml
@@ -30,7 +30,7 @@ spec:
           emptyDir: {}
       containers:
         - name: sftd-disco
-          image: quay.io/wire/sftd_disco:1.1.0
+          image: quay.io/wire/sftd_disco:1.1.1
           volumeMounts:
           - name: sftd-disco
             mountPath: /etc/wire/sftd-disco


### PR DESCRIPTION
Related to: https://wearezeta.atlassian.net/browse/WPB-15480

It's a fix PR. docker image v1.1.0 was corrupted. Fixed and tested new version


- **feat: image version bump**
- **fix: revert chart and app versions and fixed the description**
- **fix: fixed the sftd docker image**
