### PR TITLE
Fix: nginx after config nginx with new nginx image

### DIFF
--- a/charts/sftd/templates/configmap-join-call.yaml
+++ b/charts/sftd/templates/configmap-join-call.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   default.conf.template: |
     server {
-      listen 8080;
+      listen 9000;
       resolver ${NAMESERVER};
 
       location /healthz { return 204; }

--- a/charts/sftd/templates/deployment-join-call.yaml
+++ b/charts/sftd/templates/deployment-join-call.yaml
@@ -47,7 +47,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 8080
+              containerPort: 9000
               protocol: TCP
           livenessProbe:
             httpGet:
@@ -76,5 +76,5 @@ spec:
             - "-c"
             - |
               export NAMESERVER=`cat /etc/resolv.conf | grep "nameserver" | awk '{print $2}' | tr '\n' ' '`
-              envsubst '$NAMESERVER $POD_NAMESPACE' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
+              envsubst '$NAMESERVER $POD_NAMESPACE' < /etc/nginx/conf.d/default.conf.template > /opt/bitnami/nginx/conf/server_blocks/default.conf
               exec nginx -g 'daemon off;'


### PR DESCRIPTION
Follow-up to https://github.com/wireapp/wire-avs-service/pull/16 

This fixes problems:
- bitnami's nginx image uses different config files
- bitnami's nginx image already defines a server at port 8080
