### PR TITLE
WPB-16060: support for draining before termination

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update \
 
 
 WORKDIR /build/sftd
-ENV HOME /build/sftd
+ENV HOME=/build/sftd
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update \
        git \       
        clang \
        clang-tools \
+       dumb-init \
        rsync \
        gettext-base \
        libtool \
@@ -25,7 +26,9 @@ RUN apt-get update \
        libxcomposite-dev \
        libxdamage-dev \
        libxrender-dev \
-       libprotobuf-c-dev
+       libprotobuf-c-dev \
+    && apt-get clean
+
 
 WORKDIR /build/sftd
 ENV HOME /build/sftd

--- a/charts/sftd/templates/statefulset.yaml
+++ b/charts/sftd/templates/statefulset.yaml
@@ -146,6 +146,8 @@ spec:
             {{- end }}
 
           command:
+            - /usr/bin/dumb-init
+            - --
             - /bin/sh
             - -c
             - |


### PR DESCRIPTION
- **feat(helm): add dumb-init to fix signal handling**
- **fix(Dockerfile): fix LegacyKeyValueFormat warning**

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

While SFTD supports connection draining on restart, the main runtime environment (Docker) was lacking the configuration to facilitate forwarding signals to child processes.

### Solutions

We're introducing [`dumb-init`](https://github.com/Yelp/dumb-init) which has the sole purpose of properly forwarding signals and taking care of reaping child processes.

### Dependencies (Optional)

Needs releases with:

- needed by zinfra/cailleach#2584

### Testing

#### How to Test

When sent a SIGTERM signal, the process will wait until all connections are drained.
With this change, that is also expected to be working in a Docker/Kubernetes environment.

----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://wearezeta.atlassian.net/issues/WPB-7038
1. https://github.com/zinfra/cailleach/pull/2584
