### PR TITLE
WPB-16060: remove preStop hook which prevents SIGTERM from being sent

### DIFF
--- a/charts/sftd/templates/statefulset.yaml
+++ b/charts/sftd/templates/statefulset.yaml
@@ -147,7 +147,8 @@ spec:
 
           command:
             - /usr/bin/dumb-init
-            - --
+          args:
+            - --verbose
             - /bin/sh
             - -c
             - |
@@ -206,14 +207,6 @@ spec:
             httpGet:
               path: /metrics
               port: metrics
-          lifecycle:
-            preStop:
-              exec:
-                # TODO: Workaround because sftd does not support graceful draining natively.
-                # tracked in https://github.com/zinfra/backend-issues/issues/1451
-                command:
-                  - /bin/sleep
-                  - "{{ .Values.terminationGracePeriodSeconds }}"
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When Terminating a Pod, 

> A call to the PreStop [...] must complete before the TERM signal to stop the container can be sent. The Pod's termination grace period countdown begins before the PreStop hook is executed, so regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period. No parameters are passed to the handler.

Because we still had a preStop hook set, TERM was never sent to the container so SFT would never start its graceful shutdown mode.

### Solutions

Since the preStop hook is now useless, we simply remove it.

### Testing

#### How to Test

Tested by patching the `StatefulSet` and restarting it manually.

----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
