### PR TITLE
WPB-16060: set production-like default Helm values for shutdownGracePeriod

### DIFF
--- a/charts/sftd/values.yaml
+++ b/charts/sftd/values.yaml
@@ -27,7 +27,7 @@ metrics:
 
 # The time to wait after terminating an sft node before shutting it down. No
 # new calls will be initiated whilst a pod is being terminated.
-terminationGracePeriodSeconds: 10
+terminationGracePeriodSeconds: 7200 # 2 hours
 
 podAnnotations: {}
 


### PR DESCRIPTION

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We always needed to override these values per environment. Since SFT supports draining, we can now confidently set a high default shutdownGracePeriod which should be appropriate for all environments.

### Testing

#### How to Test

This was already tested by overriding the values from Terraform and applying to `staging`.
