### PR TITLE
feat/vferdinandov/WPB 17414 SFT sidecar doesn't wait for node IP to be assigned

### DIFF
--- a/charts/sftd/templates/statefulset.yaml
+++ b/charts/sftd/templates/statefulset.yaml
@@ -62,15 +62,32 @@ spec:
             - -c
             - |
               set -e
+              max_tries=30
+              count=0
 
-              # In the cloud, this setting is available to indicate the true IP address
-              addr=$(kubectl get node $NODE_NAME -ojsonpath='{.status.addresses[?(@.type=="ExternalIP")].address}')
+              while [ "$count" -lt "$max_tries" ]; do
+                # In the cloud, this setting is available to indicate the true IP address
+                addr=$(kubectl get node $NODE_NAME -ojsonpath='{.status.addresses[?(@.type=="ExternalIP")].address}')
+                
+                # On on-prem we allow people to set "wire.com/external-ip" to be used if no ExternalIP is detected
+                if [ -z "$addr" ]; then
+                  addr=$(kubectl get node $NODE_NAME -ojsonpath='{.metadata.annotations.wire\.com/external-ip}')
+                fi
 
-              # On on-prem we allow people to set  "wire.com/external-ip" to override this
+                if [ -n "$addr" ]; then
+                  echo -n "$addr" | tee /dev/stderr > /external-ip/ip
+                  break
+                fi
+
+                count=$((count + 1))
+                echo "Waiting for external IP... ($count/$max_tries)"
+                sleep 10
+              done
+
               if [ -z "$addr" ]; then
-                addr=$(kubectl get node $NODE_NAME -ojsonpath='{.metadata.annotations.wire\.com/external-ip}')
+                echo "Error: No external IP found after $max_tries attempts." >&2
+                exit 1
               fi
-              echo -n "$addr" | tee /dev/stderr > /external-ip/ip
 
         {{- if and .Values.multiSFT.enabled .Values.multiSFT.discoveryRequired }}
         - name: get-multi-sft-config


### PR DESCRIPTION
Ticket: https://wearezeta.atlassian.net/browse/WPB-17414

Adds a loop to the sidecar container that allows to wait until the external IP is assigned to the pod


- **feat: add loop to wait for external IP is attached**

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Sometimes external IP is not assigned before the sidecar script finished. Solution: add loop

#### How to Test

Deploy this helm chart version and look to the logs. Expected behavior: Every 10 seconds it will check if the external IP is attached. After IP is attached, the loop exits.