### PR TITLE
WPB-23564: import sftd_disco tool to this repo

### DIFF
--- a/.github/workflows/sftd_disco-release.yml
+++ b/.github/workflows/sftd_disco-release.yml
@@ -10,25 +10,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: quay.io/wire/sftd_disco
           tags: |
             type=match,pattern=sftd_disco-(.*),group=1
 
       - name: Log in to Quay.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_IO_ROBOT_USER }}
           password: ${{ secrets.QUAY_IO_ROBOT_PASS }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: tools/sftd_disco
           push: true

--- a/.github/workflows/sftd_disco-release.yml
+++ b/.github/workflows/sftd_disco-release.yml
@@ -1,0 +1,36 @@
+name: sftd_disco release
+
+on:
+  push:
+    tags:
+      - 'sftd_disco-*'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: quay.io/wire/sftd_disco
+          tags: |
+            type=match,pattern=sftd_disco-(.*),group=1
+
+      - name: Log in to Quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_IO_ROBOT_USER }}
+          password: ${{ secrets.QUAY_IO_ROBOT_PASS }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: tools/sftd_disco
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -9,4 +9,10 @@ To build:
 - Clone this repository using git clone --recursive
 - Run docker build ./
 
+## tools/sft_disco
+This is the SFT discovery service. It is used to discover the SFT service on the network and to register the SFT service with the AVS service registry.
 
+To build, run the following command in the tools/sft_disco directory:
+```
+docker build -t sft_disco .
+```

--- a/charts/sftd/templates/deployment-join-call.yaml
+++ b/charts/sftd/templates/deployment-join-call.yaml
@@ -35,11 +35,12 @@ spec:
           - name: sftd-disco
             mountPath: /etc/wire/sftd-disco
             readOnly: false
-          command:
-            - "/bin/sh"
-            - "-c"
-            - |
-              /usr/bin/sftd_disco.sh _sft._tcp.{{ include "sftd.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+          args:
+            - _sft._tcp.{{ include "sftd.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsRoot: false
+            runAsUser: 65534 # non-root user in alpine
         - name: nginx
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/tools/sftd_disco/Dockerfile
+++ b/tools/sftd_disco/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.23.3
+
+RUN apk add --no-cache curl bash openssl bind-tools jq
+
+COPY sftd_disco.sh /usr/bin/sftd_disco.sh
+
+ENTRYPOINT ["/usr/bin/sftd_disco.sh"]

--- a/tools/sftd_disco/Dockerfile
+++ b/tools/sftd_disco/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.23.3
 
 RUN apk add --no-cache curl bash openssl bind-tools jq
-
 COPY sftd_disco.sh /usr/bin/sftd_disco.sh
 
+USER nobody
 ENTRYPOINT ["/usr/bin/sftd_disco.sh"]

--- a/tools/sftd_disco/README.md
+++ b/tools/sftd_disco/README.md
@@ -1,0 +1,5 @@
+# sftd-disco
+
+This DISCOvery docker image/bash script converts the result from an SRV DNS lookup of a kubernetes service to a file which can be served by nginx or similar.
+
+This is useful as a sidecar container to the sftd chart in kubernetes to expose the full list of running sftd servers in cases where sftd runs independently from other backend services. See also [the sftd helm chart](https://github.com/wireapp/wire-server/tree/develop/charts/sftd/)

--- a/tools/sftd_disco/sftd_disco.sh
+++ b/tools/sftd_disco/sftd_disco.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+exec 2>&1
+
+# Assumes /etc/wire/sftd-disco/ directory exists.
+
+USAGE="example usage: $0 _sft._tcp.wire-server-sftd.wire.svc.cluster.local"
+srv_name=${1?$USAGE}
+
+old="/etc/wire/sftd-disco/sft_servers_all.json"
+new="${old}.new"
+
+function valid_entry() {
+    # TODO sanity check that this is real dig output
+    return 0
+}
+
+function valid_url() {
+    #TODO basic sanity check
+    return 0
+}
+
+# for a given SRV record
+# 1. lookup the record
+# 2. for each entry: extract host and port and call 'curl host:port/sft/url'
+# 4. save the resulting URLs as a json array to a file
+# this file can then be served from nginx running besides sft
+function upstream() {
+    name=$1
+    entries=$(dig +short +retries=3 +search SRV "${name}" | sort)
+    unset servers
+    comma=""
+    IFS=$'\t\n'
+    for entry in $entries; do
+        if valid_entry "$entry"; then
+            sft_host_port=$(echo "$entry" | awk '{print $4":"$3}')
+            sft_url=$(curl -s http://"$sft_host_port"/sft/url | xargs)
+            if valid_url "$sft_url"; then
+                servers+=("$comma"'"'"$sft_url"'"')
+                comma=","
+            fi
+        fi
+    done
+    # shellcheck disable=SC2128
+    if [ -n "$servers" ]; then
+        echo '{"sft_servers_all": ['"${servers[*]}"']}' | jq >${new}
+    else
+        printf "" >>${new}
+    fi
+}
+
+function routing_disco() {
+    srv_name=$1
+    ivl=$(echo | awk '{ srand(); printf("%f", 2.5 + rand() * 1.5) }')
+
+    [[ -f $old ]] || touch -d "1970-01-01" $old
+
+    echo "" >${new}
+    upstream "$srv_name"
+
+    diff -q $old $new || {
+        echo upstream change found, replacing $old with $new
+        mv $new $old
+    }
+
+    rm -f $new
+
+    echo done, sleeping "$ivl"
+    sleep "$ivl"
+}
+
+while true; do
+    routing_disco "$srv_name"
+done


### PR DESCRIPTION
# What's new in this PR?

### Issues

The sftd_disco tool is used in this repo's helm chart, but was previously maintained within `wire-server`.
The `Dockerfile` was based on an old Alpine image with many CVEs.

### Solutions
* [x] move sftd_disco tool from wire-server to this repo so it can be maintained here
* [x] update base image to alpine:3.23.3
* [x] add simple GHA workflow to push releases

### Dependencies

* [x] A quay.io robot account and secret were created and onboarded to this repo.
* [ ] After creating a first release (e.g. named `sftd_disco-1.1.2`), the `sftd` Helm chart needs to be updated with the created docker tag and a new patch version needs to be released.

### Testing

* [x] I have manually tested the updated image + `runAsUser` change on  `chala`
* [ ] To test the release workflow, a release tagged with `sftd_disco-1.1.2` needs to be created after merging this PR.

---

related to WPB-23568
related to WPB-23564