### PR TITLE
WPB-23247: make images configurable + upgrade kubctl

### DIFF
--- a/charts/sftd/templates/deployment-join-call.yaml
+++ b/charts/sftd/templates/deployment-join-call.yaml
@@ -30,7 +30,10 @@ spec:
           emptyDir: {}
       containers:
         - name: sftd-disco
-          image: quay.io/wire/sftd_disco:wip-2 # TODO configure + version
+          {{- with .Values.sftdDisco.image }}
+          image: {{ .repository }}:{{ .tag }}
+          imagePullPolicy: {{ .pullPolicy }}
+          {{- end }}
           volumeMounts:
           - name: sftd-disco
             mountPath: /etc/wire/sftd-disco

--- a/charts/sftd/templates/statefulset.yaml
+++ b/charts/sftd/templates/statefulset.yaml
@@ -54,7 +54,10 @@ spec:
       {{- end }}
       initContainers:
         - name: get-external-ip
-          image: bitnami/kubectl:1.24.12
+          {{- with .Values.externalIpHelper.image }}
+          image: {{ .repository }}:{{ .tag }}
+          imagePullPolicy: {{ .pullPolicy }}
+          {{- end }}
           volumeMounts:
             - name: external-ip
               mountPath: /external-ip
@@ -63,8 +66,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          command:
-            - /bin/sh
+          command: [/bin/sh]
+          args:
             - -c
             - |
               set -e
@@ -77,7 +80,10 @@ spec:
                 addr=$(kubectl get node $NODE_NAME -ojsonpath='{.metadata.annotations.wire\.com/external-ip}')
               fi
               echo -n "$addr" | tee /dev/stderr > /external-ip/ip
-
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsRoot: false
+            runAsUser: 65534 # nobody user in the kubectl image
         {{- if and .Values.multiSFT.enabled .Values.multiSFT.discoveryRequired }}
         - name: get-multi-sft-config
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/sftd/values.yaml
+++ b/charts/sftd/values.yaml
@@ -56,6 +56,15 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+externalIpHelper:
+  # The image used for the initContainer that determines the external IP address of the node.
+  # This is a very small image that just contains kubectl, and is only used during startup.
+  # We chose the `compat` flavor of the image since we need a shell to run the command that determines the external IP address, and the `compat` image includes a shell.
+  image:
+    repository: docker.io/alpine/kubectl
+    pullPolicy: IfNotPresent
+    tag: 1.35.1
+
 # If you have multiple deployments of sftd running in one cluster, it is
 # important that they run on disjoint sets of nodes, you can use nodeSelector to enforce this
 nodeSelector: {}

--- a/charts/sftd/values.yaml
+++ b/charts/sftd/values.yaml
@@ -87,6 +87,11 @@ joinCall:
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
     tag: "1.25.3"
+sftdDisco:
+  image:
+    repository: quay.io/wire/sftd_disco
+    pullPolicy: IfNotPresent
+    tag: "1.1.1" # sftd_disco is released separately from sftd, so it doesn't share the same version number
 
 # Allow SFT instances to choose/consider using a TURN server for themselves as a proxy when
 # trying to establish a connection to clients

--- a/charts/sftd/values.yaml
+++ b/charts/sftd/values.yaml
@@ -80,22 +80,21 @@ tls: {}
   # key:
   # crt:
   # issuerRef:
-    # The name of the issuer (e.g. letsencrypr-prod)
-    # name: ca-issuer
-    # We can reference ClusterIssuers by changing the kind here.
-    # The default value is Issuer (i.e. a locally namespaced Issuer)
-    # kind: Issuer
-    # This is optional since cert-manager will default to this value however
-    # if you are using an external issuer, change this to that issuer group.
-    # group: cert-manager.io
+  # The name of the issuer (e.g. letsencrypr-prod)
+  # name: ca-issuer
+  # We can reference ClusterIssuers by changing the kind here.
+  # The default value is Issuer (i.e. a locally namespaced Issuer)
+  # kind: Issuer
+  # This is optional since cert-manager will default to this value however
+  # if you are using an external issuer, change this to that issuer group.
+  # group: cert-manager.io
 
 joinCall:
   replicaCount: 3
   image:
     repository: nginxinc/nginx-unprivileged
     pullPolicy: IfNotPresent
-    # Overrides the image tag whose default is the chart appVersion.
-    tag: "1.25.3"
+    tag: "1.29.5-alpine3.23-perl"
 sftdDisco:
   image:
     repository: quay.io/wire/sftd_disco


### PR DESCRIPTION
# What's new in this PR?

### Issues

* the `bitnami/kubectl` image used in the `get-external-ip` initContainer is EOL and has many CVEs
* `nginxinc/nginx-unprivileged` uses an old version
* also, the repo and tag for the external-ip helper as well as `sftd_disco` are hard-coded

### Solutions

* `externalIpHelper.image` and `sftdDisco.image` values are added to the Chart to make images+tags easily configurable
* moved from `bitnami/kubectl` to `alpine/kubectl`, which has a similarly small footprint
* updated to support recent Kubernetes versions
* set latest `sftd_disco` tag
* updated `nginxinc/nginx-unprivileged` to `1.29.5`
* bump Chart version to `0.0.43`

### Testing

#### How to Test

The change has been manually tested in a QA environment by rendering the chart + applying the Statefulset. The external IP of the node running the pod was properly written to the expected path.


### Notes
Related to WPB-18320 and WPB-23247
