### PR TITLE
Remove digest(sha256) from tag for nginx image in joinCall

### DIFF
--- a/charts/sftd/values.yaml
+++ b/charts/sftd/values.yaml
@@ -85,7 +85,7 @@ joinCall:
   image:
     repository: docker.io/bitnamilegacy/nginx
     pullPolicy: IfNotPresent
-    tag: "1.27.3-debian-12-r5@sha256:c02e18884badbd9482fd731668f75a3033124c748bc709651fb06062d0ab38c1"
+    tag: "1.27.3-debian-12-r5"
 
 # Allow SFT instances to choose/consider using a TURN server for themselves as a proxy when
 # trying to establish a connection to clients


### PR DESCRIPTION
When building the deployment bundle in wire-server-deploy, we currently reference the nginx image using a tag + digest:

`1.27.3-debian-12-r5@sha256:c02e18884badbd9482fd731668f75a3033124c748bc709651fb06062d0ab38c1`

During bundle creation we are able to pull the image successfully using the exact digest from the registry. However, when the image is later exported to a tar archive and shipped inside the on-prem bundle, the manifest digest changes depending on how the image is packed (e.g., differences between registry manifests vs. locally generated manifests when exporting/importing). We have ticket to understand if we can fix this digest change at the source. As of now, no other images are being fixed on a digest apart from this current nginx image.

As a result:
The bundle contain a locally generated manifest for the image that has a different digest than the original registry manifest.
When a pod references the image using tag@sha256:c02e1888, containerd expects the exact registry digest chain to exist locally.
Since the locally imported image have a different manifest digest, Kubernetes cannot resolve the image locally and attempts to pull it from the registry, which fails in air-gapped / on-prem environments.


The image loaded from our artifact has a different hash:
```bash
demo@kubenode3:~$ curl -q "192.168.122.130:8080/containers-helm/docker.io_bitnamilegacy_nginx_1.27.3-debian-12-r5@sha256_c02e18884badbd9482fd731668f75a3033124c748bc709651fb06062d0ab38c1.tar" | sudo ctr -n=k8s.io images import -
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  181M  100  181M    0     0   210M      0 --:--:-- --:--:-- --:--:--  210M
unpacking docker.io/bitnamilegacy/nginx:1.27.3-debian-12-r5 (sha256:70fb16f4604b34a8bc0050fa9f2570593dc8a542bb16c5a5268b35779c8cd26b)...done

demo@kubenode3:~$ sudo ctr -n k8s.io images ls | grep bitnamilegacy/nginx
docker.io/bitnamilegacy/nginx:1.27.3-debian-12-r5                       application/vnd.docker.distribution.manifest.v2+json sha256:70fb16f4604b34a8bc0050fa9f2570593dc8a542bb16c5a5268b35779c8cd26b 181.4 MiB linux/amd64 io.cri-containerd.image=managed                                 
---
demo@kubenode3:~$ sudo ctr -n k8s.io content get sha256:c02e18884badbd9482fd731668f75a3033124c748bc709651fb06062d0ab38c1 | jq .
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
  "manifests": [
    {
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "size": 429,
      "digest": "sha256:52aaaacae0b8473f4354741fea3742825ae70cf20d77cb54f64a79fdcf9ecb3c",
      "platform": {
        "architecture": "amd64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "size": 429,
      "digest": "sha256:ef4035c5334e980debdfc25be644b5548739ec7f058e4f15feb0966addcda714",
      "platform": {
        "architecture": "arm64",
        "os": "linux"
      }
    }
  ]
}

demo@kubenode3:~$ sudo ctr -n k8s.io content get sha256:70fb16f4604b34a8bc0050fa9f2570593dc8a542bb16c5a5268b35779c8cd26b | jq .
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
  "config": {
    "mediaType": "application/vnd.docker.container.image.v1+json",
    "digest": "sha256:f5c585c24508977ff8290cb471e12f9c4ffdfdb94f0bfd4f739f9a76d71c3dd0",
    "size": 8084
  },
  "layers": [
    {
      "mediaType": "application/vnd.docker.image.rootfs.diff.tar",
      "digest": "sha256:6d116716c10c87d809c3443b99eac74e90274ed77c21c08ab82cd48cc4501c3f",
      "size": 190155264
    }
  ]
}

demo@kubenode3:~$ sudo ctr -n k8s.io content get sha256:52aaaacae0b8473f4354741fea3742825ae70cf20d77cb54f64a79fdcf9ecb3c | jq .
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
  "config": {
    "mediaType": "application/vnd.docker.container.image.v1+json",
    "size": 8084,
    "digest": "sha256:f5c585c24508977ff8290cb471e12f9c4ffdfdb94f0bfd4f739f9a76d71c3dd0"
  },
  "layers": [
    {
      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
      "size": 67085765,
      "digest": "sha256:71bd7d98fb50b9b615d8ff4b064430085d0d0d7c99c0b28ca4b568741a6101d9"
    }
  ]
}


```

When forced a complete no internet (No DNS) deployment, the `sftd-call-join` pod failed, even when the image was loaded to the node:
```bash
  Normal   Pulling    40s   kubelet            Pulling image "docker.io/bitnamilegacy/nginx:1.27.3-debian-12-r5@sha256:c02e18884badbd9482fd731668f75a3033124c748bc709651fb06062d0ab38c1"
  Warning  Failed     0s    kubelet            Failed to pull image "docker.io/bitnamilegacy/nginx:1.27.3-debian-12-r5@sha256:c02e18884badbd9482fd731668f75a3033124c748bc709651fb06062d0ab38c1": failed to pull and unpack image "docker.io/bitnamilegacy/nginx@sha256:c02e18884badbd9482fd731668f75a3033124c748bc709651fb06062d0ab38c1": failed to resolve reference "docker.io/bitnamilegacy/nginx@sha256:c02e18884badbd9482fd731668f75a3033124c748bc709651fb06062d0ab38c1": failed to do request: Head "https://registry-1.docker.io/v2/bitnamilegacy/nginx/manifests/sha256:c02e18884badbd9482fd731668f75a3033124c748bc709651fb06062d0ab38c1": dial tcp: lookup registry-1.docker.io on 127.0.0.53:53: read udp 127.0.0.1:47185->127.0.0.53:53: i/o timeout
  Warning  Failed     0s    kubelet            Error: ErrImagePull

```


In contrast, when the pod references the image using only the tag: `1.27.3-debian-12-r5`, containerd can resolve the locally imported image successfully because the tag matches the image reference created during the tar import.

When removed the digest of the tag and re-deoloyed the pod for `sftd-call-join`:
```bash
Node-Selectors:              kubernetes.io/hostname=kubenode3
Tolerations:                 node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                             node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type    Reason     Age   From               Message
  ----    ------     ----  ----               -------
  Normal  Scheduled  9s    default-scheduler  Successfully assigned default/sftd-join-call-cfb7c7598-27ljk to kubenode3
  Normal  Pulled     9s    kubelet            Container image "quay.io/wire/sftd_disco:1.1.1" already present on machine
  Normal  Created    9s    kubelet            Created container sftd-disco
  Normal  Started    9s    kubelet            Started container sftd-disco
  Normal  Pulled     9s    kubelet            Container image "docker.io/bitnamilegacy/nginx:1.27.3-debian-12-r5" already present on machine

```
This PR removes the digest suffix from the nginx image reference and uses only the tag `1.27.3-debian-12-r5`.
This ensures the image can be resolved correctly when loaded from the bundled tar archive in on-prem deployments.

Using a digest provides strong immutability guarantees, ensuring the exact image from the registry is used. However, in our current on-prem bundle workflow (tar export → transfer → import), the digest may not remain stable, which breaks local resolution. Do we have stronger reasons to keep it?  If yes, we can override it on our end as well but that can create 2 sources of truth for the same image.

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

_Briefly describe the issue you have solved or implemented with this pull request. If the PR contains multiple issues, use a bullet list._

### Causes (Optional)

_Briefly describe the causes behind the issues. This could be helpful to understand the adopted solutions behind some nasty bugs or complex issues._

### Solutions

_Briefly describe the solutions you have implemented for the issues explained above._

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
