### PR TITLE
helm chart: runAsRoot -> runAsNonRoot

### DIFF
--- a/charts/sftd/templates/statefulset.yaml
+++ b/charts/sftd/templates/statefulset.yaml
@@ -82,7 +82,7 @@ spec:
               echo -n "$addr" | tee /dev/stderr > /external-ip/ip
           securityContext:
             allowPrivilegeEscalation: false
-            runAsRoot: false
+            runAsNonRoot: true
             runAsUser: 65534 # nobody user in the kubectl image
         {{- if and .Values.multiSFT.enabled .Values.multiSFT.discoveryRequired }}
         - name: get-multi-sft-config


### PR DESCRIPTION
Follow-up to https://github.com/wireapp/wire-avs-service/pull/39, fixing non-existent policy name in helm chart.

Reference: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted