### PR TITLE
Change SFTD graceperiod to 0 (zero) seconds

### DIFF
--- a/charts/sftd/README.md
+++ b/charts/sftd/README.md
@@ -50,7 +50,7 @@ usage: sftd [-a] [-I <addr>] [-p <port>] [-A <addr>] [-M <addr>] [-r <port>] [-u
 
 | Parameter                       | Default | Description                                                                                                                                                                           |
 |---------------------------------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `terminationGracePeriodSeconds` | `10`    | The time to wait after terminating an sft node before shutting it down. Useful to wait for a pod to have less calls before shutting down. Pod won't take new calls whilst terminating |
+| `terminationGracePeriodSeconds` | `0`     | The time to wait after terminating an sft node before shutting it down. Useful to wait for a pod to have less calls before shutting down. Pod won't take new calls whilst terminating |
 | `replicaCount`                  | `1`     | Amount of SFT servers to run. Only one SFT server can run per node. So  `replicaCount <= nodeCount`                                                                                   |
 | `nodeSelector`, `affinity`      | `{}`    | Used to constraint SFT servers to only run on specific nodes                                                                                                                          |
 | `coredeumps.enabled`            | `false` | Enable recording of coredumps for testing and debugging.                                                                                                                              |

--- a/charts/sftd/values.yaml
+++ b/charts/sftd/values.yaml
@@ -27,7 +27,7 @@ metrics:
 
 # The time to wait after terminating an sft node before shutting it down. No
 # new calls will be initiated whilst a pod is being terminated.
-terminationGracePeriodSeconds: 10
+terminationGracePeriodSeconds: 0
 
 podAnnotations: {}
 


### PR DESCRIPTION
Ticket: https://wearezeta.atlassian.net/browse/WPB-27835

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
We need to reduce this downtime to a minimum for `sftd` to speedup rollout

### Solutions
make GracePeriod time to 0 (zero) by default
